### PR TITLE
rotation -> rotate in docs

### DIFF
--- a/doc/wordcloud-doc-en.tex
+++ b/doc/wordcloud-doc-en.tex
@@ -345,7 +345,7 @@ have the same options:
   \hologo{METAPOST}.} ;
   \item[\texttt{margin=}\meta{value with units}:] to adjust the margins
   (default \lstinline+0.3pt+) ;
-  \item[\texttt{rotation=}\meta{angle}:] to rotate (degrees) the words with
+  \item[\texttt{rotate=}\meta{angle}:] to rotate (degrees) the words with
   $\pm$\meta{angle} alternatively (default 0) ;
   \item[\texttt{usecolor}:] to use color for word drawing (boolean, default
   \lstinline+false+) as described in section~\ref{sec:colors} ;

--- a/doc/wordcloud-doc-en.txt
+++ b/doc/wordcloud-doc-en.txt
@@ -453,7 +453,7 @@ METAPOST.
 6
 
 margin=⟨value with units⟩: to adjust the margins (default 0.3pt) ;
-rotation=⟨angle⟩: to rotate (degrees) the words with ±⟨angle⟩ alternatively
+rotate=⟨angle⟩: to rotate (degrees) the words with ±⟨angle⟩ alternatively
 (default 0) ;
 usecolor: to use color for word drawing (boolean, default false) as described in section 2.3.1 ;
 colors=⟨list of colors⟩: to define a new set of colors as described in section 2.3.15 .

--- a/wordcloud.sty
+++ b/wordcloud.sty
@@ -55,7 +55,7 @@
   % mandatory argument : list (word1,weight1);(word2,weight2);etc.
   % optional arguments :
   % scale=<value> (default 1)
-  % rotation=<value> (default 0)
+  % rotate=<value> (default 0)
   % margin=<value> (default 0.3pt)
   % usecolor=true/false (default false)
   % colors={color1,color2,etc}
@@ -99,7 +99,7 @@
   % wordcloud 
   % optional arguments :
   % scale=<value> (default 1)
-  % rotation=<value> (default 0)
+  % rotate=<value> (default 0)
   % margin=<value> (default 0.3pt)
   % usecolor=true/false (default false)
   % colors={color1,color2,etc}


### PR DESCRIPTION
Changed occurrences of key `rotation` in docs to the correct key `rotate`.